### PR TITLE
Pan map when marker is obscured by BusinessInfoWindow

### DIFF
--- a/src/components/MapCenter/components/MapOverlay.tsx
+++ b/src/components/MapCenter/components/MapOverlay.tsx
@@ -1,6 +1,6 @@
 import { AnimatePresence } from 'motion/react';
 import React from 'react';
-import type { Business } from '../../../types';
+import type { Business, ElementBounds } from '../../../types';
 import { BusinessInfoWindow } from '../../BusinessInfoWindow';
 import { LoadingOverlay } from '../../LoadingOverlay';
 
@@ -8,10 +8,16 @@ interface MapOverlayProps {
 	isFetching: boolean;
 	message?: string;
 	selectedBusiness: Business | undefined;
+	onInfoWindowBoundsMeasured?: (bounds: ElementBounds) => void;
 }
 
 export const MapOverlay = React.memo(
-	({ isFetching, message, selectedBusiness }: MapOverlayProps) => {
+	({
+		isFetching,
+		message,
+		selectedBusiness,
+		onInfoWindowBoundsMeasured,
+	}: MapOverlayProps) => {
 		return (
 			<>
 				<AnimatePresence>{isFetching && <LoadingOverlay />}</AnimatePresence>
@@ -20,6 +26,7 @@ export const MapOverlay = React.memo(
 						<BusinessInfoWindow
 							key={selectedBusiness.alias}
 							business={selectedBusiness}
+							onBoundsMeasured={onInfoWindowBoundsMeasured}
 						/>
 					)}
 				</AnimatePresence>
@@ -29,4 +36,3 @@ export const MapOverlay = React.memo(
 );
 
 MapOverlay.displayName = 'MapOverlay';
-

--- a/src/components/MapCenter/constants.ts
+++ b/src/components/MapCenter/constants.ts
@@ -1,1 +1,11 @@
 export const MAX_ZOOM = 17;
+export const DEFAULT_ZOOM = 13;
+export const DEFAULT_DEBOUNCE = 300;
+export const PAN_DELAY_MS = 200;
+export const MAX_MAP_ANIMATION_DURATION_MS = 1000;
+export const MARKER_PAN_ANIMATION_DURATION_MS = 700;
+
+export const DEFAULT_CENTER: google.maps.LatLngLiteral = {
+	lat: 34.04162072763611,
+	lng: -118.26326182991187,
+};

--- a/src/components/MapCenter/hooks/useClusterClick.ts
+++ b/src/components/MapCenter/hooks/useClusterClick.ts
@@ -6,14 +6,18 @@ import { MAX_ZOOM } from '../constants';
 interface UseClusterClickParams {
 	mapboxMapRef: React.RefObject<MapRef>;
 	supercluster: Supercluster<Supercluster.AnyProps, Supercluster.AnyProps>;
+	deselectBusiness: () => void;
 }
 
 export const useClusterClick = ({
 	mapboxMapRef,
 	supercluster,
+	deselectBusiness,
 }: UseClusterClickParams) => {
 	const handleClusterClick = useCallback(
 		(cluster: Supercluster.ClusterFeature<Supercluster.AnyProps>) => {
+			deselectBusiness();
+
 			const [longitude, latitude] = cluster.geometry.coordinates;
 
 			// Get the base cluster expansion zoom
@@ -42,7 +46,7 @@ export const useClusterClick = ({
 				});
 			}
 		},
-		[supercluster, mapboxMapRef],
+		[supercluster, mapboxMapRef, deselectBusiness],
 	);
 
 	return handleClusterClick;

--- a/src/components/MapCenter/hooks/useMarkerPanning.ts
+++ b/src/components/MapCenter/hooks/useMarkerPanning.ts
@@ -1,0 +1,94 @@
+import { useCallback } from 'react';
+import type { MapRef } from 'react-map-gl';
+import type { ElementBounds } from '../../../types';
+import {
+	MARKER_PAN_ANIMATION_DURATION_MS,
+	MAX_MAP_ANIMATION_DURATION_MS,
+} from '../constants';
+
+interface UseMarkerPanningParams {
+	mapboxMapRef: React.RefObject<MapRef>;
+}
+
+export const useMarkerPanning = ({ mapboxMapRef }: UseMarkerPanningParams) => {
+	const panToKeepMarkerVisible = useCallback(
+		(
+			latitude: number,
+			longitude: number,
+			infoWindowBounds: ElementBounds | null,
+		) => {
+			if (
+				!mapboxMapRef.current ||
+				!infoWindowBounds ||
+				infoWindowBounds.height === 0
+			) {
+				return;
+			}
+
+			const map = mapboxMapRef.current.getMap();
+			if (!map) return;
+
+			// Convert marker coordinates to pixel coordinates
+			const point = map.project([longitude, latitude]);
+
+			// Get viewport dimensions
+			const viewportHeight = window.innerHeight;
+
+			// Calculate the vertical bounds of the info window
+			// The window's top edge is at (bottom - height), and bottom edge is at bottom
+			const windowTop = infoWindowBounds.bottom - infoWindowBounds.height;
+			const windowBottom = infoWindowBounds.bottom;
+
+			// Calculate the horizontal bounds of the info window
+			const windowLeft = infoWindowBounds.left;
+			const windowRight = infoWindowBounds.left + infoWindowBounds.width;
+
+			// Check if marker is within the vertical bounds of the info window
+			// Add a small buffer to account for marker size and ensure it's clearly obscured
+			const bufferPixels = 50;
+			const isVerticallyWithinBounds =
+				point.y >= windowTop - bufferPixels &&
+				point.y <= windowBottom + bufferPixels;
+
+			// Check if marker is within the horizontal bounds of the info window
+			const isHorizontallyWithinBounds =
+				point.x >= windowLeft - bufferPixels &&
+				point.x <= windowRight + bufferPixels;
+
+			// Only pan if marker is within BOTH vertical AND horizontal bounds of the window
+			if (isVerticallyWithinBounds && isHorizontallyWithinBounds) {
+				// Calculate target position: move marker above the window with buffer
+				const targetMarkerY = windowTop - bufferPixels;
+				// Marker would be obscured, calculate how much we need to pan
+				// To move marker up on screen, we need to pan the map down (move map content up)
+				const panOffsetPixels = point.y - targetMarkerY;
+
+				// Get current map center
+				const currentCenter = map.getCenter();
+				const currentCenterPoint = map.project([
+					currentCenter.lng,
+					currentCenter.lat,
+				]);
+
+				// Calculate new center point by panning down (moving map up)
+				// To move content up by X pixels, we move the center down by X pixels
+				const newCenterPoint: [number, number] = [
+					currentCenterPoint.x,
+					currentCenterPoint.y + panOffsetPixels,
+				];
+
+				// Convert the new center point back to lat/lng
+				const newCenter = map.unproject(newCenterPoint);
+
+				// Pan the map to keep marker visible
+				mapboxMapRef.current.flyTo({
+					center: [newCenter.lng, newCenter.lat],
+					duration: MARKER_PAN_ANIMATION_DURATION_MS,
+				});
+			}
+		},
+		[mapboxMapRef],
+	);
+
+	return panToKeepMarkerVisible;
+};

--- a/src/components/MapCenter/index.tsx
+++ b/src/components/MapCenter/index.tsx
@@ -6,26 +6,26 @@ import { useDebounce } from 'use-debounce';
 import useBusinesses from '../../hooks/useBusinesses';
 import useLocation, { type LocationState } from '../../hooks/useLocation';
 import { useSearchFilterStore } from '../../store/searchFilterStore';
-import type { Business } from '../../types';
+import type { Business, ElementBounds } from '../../types';
 import { MapboxMapScreen, getBbox } from '../MapRender';
 import { SearchBar } from '../SearchBar';
 import UserLocationMarker from '../UserLocationMarker';
 import { CurrentLocationButton } from './components/CurrentLocationButton';
 import { MapMarkers } from './components/MapMarkers';
 import { MapOverlay } from './components/MapOverlay';
+import {
+	DEFAULT_CENTER,
+	DEFAULT_DEBOUNCE,
+	DEFAULT_ZOOM,
+	MAX_MAP_ANIMATION_DURATION_MS,
+	PAN_DELAY_MS,
+} from './constants';
 import { useClusterClick } from './hooks/useClusterClick';
 import { useFilteredBusinesses } from './hooks/useFilteredBusinesses';
 import { useMapInteractions } from './hooks/useMapInteractions';
 import { useMapboxViewport } from './hooks/useMapboxViewport';
+import { useMarkerPanning } from './hooks/useMarkerPanning';
 import { useSupercluster } from './hooks/useSupercluster';
-
-const DEFAULT_CENTER: google.maps.LatLngLiteral = {
-	lat: 34.04162072763611,
-	lng: -118.26326182991187,
-};
-
-const DEFAULT_ZOOM = 13;
-const DEFAULT_DEBOUNCE = 300;
 
 const OVERRIDE_USER_LOCATION =
 	JSON.parse(import.meta.env.VITE_OVERRIDE_USER_LOCATION) ?? false;
@@ -46,6 +46,8 @@ const MapCenter = () => {
 	const { data: businesses, isFetching } = useBusinesses();
 
 	const [selectedBusiness, setSelectedBusiness] = useState<Business>();
+	const [infoWindowBounds, setInfoWindowBounds] =
+		useState<ElementBounds | null>(null);
 
 	const {
 		searchTerm,
@@ -99,6 +101,17 @@ const MapCenter = () => {
 
 	const checkAndUpdateViewport = useMapboxViewport();
 
+	const panToKeepMarkerVisible = useMarkerPanning({
+		mapboxMapRef,
+	});
+
+	const handleInfoWindowBoundsMeasured = useCallback(
+		(bounds: ElementBounds) => {
+			setInfoWindowBounds(bounds);
+		},
+		[],
+	);
+
 	// Update selected business when businesses data changes
 	useEffect(() => {
 		if (businesses && businesses.length > 0 && selectedBusiness) {
@@ -112,6 +125,31 @@ const MapCenter = () => {
 			}
 		}
 	}, [businesses, selectedBusiness, deselectBusiness]);
+
+	// Pan map to keep marker visible when business is selected and bounds are measured
+	useEffect(() => {
+		if (
+			selectedBusiness?.yelpData?.coordinates &&
+			infoWindowBounds &&
+			infoWindowBounds.height > 0 &&
+			mapboxMapRef.current
+		) {
+			const { latitude, longitude } = selectedBusiness.yelpData.coordinates;
+			// Use setTimeout to ensure the map is ready and measurements are complete
+			const timeoutId = setTimeout(() => {
+				panToKeepMarkerVisible(latitude, longitude, infoWindowBounds);
+			}, PAN_DELAY_MS);
+
+			return () => clearTimeout(timeoutId);
+		}
+	}, [selectedBusiness, infoWindowBounds, panToKeepMarkerVisible]);
+
+	// Reset info window bounds when business is deselected
+	useEffect(() => {
+		if (!selectedBusiness) {
+			setInfoWindowBounds(null);
+		}
+	}, [selectedBusiness]);
 
 	const handleMapMoveEnd = (e: ViewStateChangeEvent) => {
 		if (mapboxMapRef.current) {
@@ -155,11 +193,15 @@ const MapCenter = () => {
 					userLocation.longitude &&
 					mapboxMapRef?.current?.flyTo({
 						center: [userLocation.longitude, userLocation.latitude],
-						maxDuration: 1000,
+						maxDuration: MAX_MAP_ANIMATION_DURATION_MS,
 					})
 				}
 			/>
-			<MapOverlay isFetching={isFetching} selectedBusiness={selectedBusiness} />
+			<MapOverlay
+				isFetching={isFetching}
+				selectedBusiness={selectedBusiness}
+				onInfoWindowBoundsMeasured={handleInfoWindowBoundsMeasured}
+			/>
 		</>
 	);
 };

--- a/src/components/MapCenter/index.tsx
+++ b/src/components/MapCenter/index.tsx
@@ -97,6 +97,7 @@ const MapCenter = () => {
 	const handleClusterClick = useClusterClick({
 		mapboxMapRef,
 		supercluster,
+		deselectBusiness,
 	});
 
 	const checkAndUpdateViewport = useMapboxViewport();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -72,3 +72,10 @@ export enum MapService {
 	GOOGLE = 'GOOGLE',
 	MAPBOX = 'MAPBOX',
 }
+
+export interface ElementBounds {
+	width: number;
+	height: number;
+	left: number;
+	bottom: number;
+}


### PR DESCRIPTION
## Summary
This PR adds automatic map panning functionality to ensure business markers remain visible when the BusinessInfoWindow is displayed. When a marker would be obscured by the info window, the map automatically pans to reposition the marker above the window with appropriate spacing.

## Changes
- **New hook: `useMarkerPanning`** - Detects when a marker is obscured by the BusinessInfoWindow and calculates the necessary pan offset to keep the marker visible
- **BusinessInfoWindow bounds measurement** - Added ResizeObserver to track the info window's position and dimensions, notifying the parent component when bounds change
- **MapCenter integration** - Integrated the panning hook with bounds measurement callback to enable automatic panning
- **New constants** - Added `MARKER_PAN_ANIMATION_DURATION_MS` (700ms) for smooth panning animations
- **Type definitions** - Added `ElementBounds` type to support bounds measurement
- **Cluster click handling** - Added `deselectBusiness()` call to `handleClusterClick` for proper state management

## Technical Details
- Uses pixel-based calculations to determine if a marker is within the info window's bounds (with 50px buffer)
- Converts between geographic coordinates and pixel coordinates using Mapbox's projection methods
- Only pans when marker is within both vertical AND horizontal bounds of the window
- Panning animation duration is 700ms for smooth user experience
- ResizeObserver ensures bounds are recalculated when window content changes dynamically

## Files Changed
- `src/components/MapCenter/hooks/useMarkerPanning.ts` (new file, 94 lines)
- `src/components/BusinessInfoWindow/index.tsx` (+49 lines)
- `src/components/MapCenter/index.tsx` (+65 lines)
- `src/components/MapCenter/components/MapOverlay.tsx` (+12 lines)
- `src/components/MapCenter/constants.ts` (+2 lines)
- `src/components/MapCenter/hooks/useClusterClick.ts` (+6 lines)
- `src/types/index.ts` (+7 lines)

## Testing
- Verify that when a BusinessInfoWindow appears and obscures a marker, the map automatically pans to keep the marker visible
- Test with different window sizes and marker positions
- Ensure panning doesn't occur when marker is not obscured
- Verify smooth animation behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds automatic panning to prevent the selected marker from being covered by `BusinessInfoWindow`.
> 
> - New `useMarkerPanning` hook; integrated in `MapCenter` to pan based on `ElementBounds` with a small delay
> - `BusinessInfoWindow` now measures its bounds via `ResizeObserver` and reports them through `onBoundsMeasured`; `MapOverlay` passes the callback
> - Centralizes map config in `constants.ts` (`DEFAULT_*`, `PAN_DELAY_MS`, `MAX_MAP_ANIMATION_DURATION_MS`, `MARKER_PAN_ANIMATION_DURATION_MS`) and adopts durations in callers
> - `useClusterClick` invokes `deselectBusiness()` before expanding clusters to keep selection state consistent
> - Adds `ElementBounds` type to `types`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2f4c981d2df92a4f7665be4e2679f463fbc91f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->